### PR TITLE
fix: persist freezer drag-and-drop positions

### DIFF
--- a/app/lab-map.html
+++ b/app/lab-map.html
@@ -619,7 +619,7 @@
       if (t) { var tc = t.closest('.tube-cell'); if (tc && tc !== dragging.sourceCell) tc.classList.add('drag-over'); }
     });
 
-    document.addEventListener('mouseup', function(e) {
+    document.addEventListener('mouseup', async function(e) {
       if (!dragging) return;
       var d = dragging;
       dragging = null;
@@ -633,14 +633,59 @@
       var targetCell = t.closest('.tube-cell');
       if (!targetCell || targetCell === d.sourceCell) return;
 
-      var targetItemI = targetCell.dataset.item;
-      if (targetItemI != null) {
-        var ti = parseInt(targetItemI);
-        var temp = boxItems[d.itemIdx];
-        boxItems[d.itemIdx] = boxItems[ti];
-        boxItems[ti] = temp;
+      // Compute cell labels from data-idx
+      function cellLabel(cellEl) {
+        var idx = parseInt(cellEl.dataset.idx);
+        var row = Math.floor(idx / gridSize);
+        var col = idx % gridSize;
+        return String.fromCharCode(65 + row) + (col + 1);
       }
-      Lab.showToast('Moved ' + (boxItems[d.itemIdx].title || 'item'), 'success');
+      var targetPos = cellLabel(targetCell);
+      var sourcePos = cellLabel(d.sourceCell);
+
+      var draggedItem = boxItems[d.itemIdx];
+      var targetItemI = targetCell.dataset.item;
+      var targetItem = targetItemI != null ? boxItems[parseInt(targetItemI)] : null;
+
+      // Build new location_detail strings
+      var newDraggedDetail = buildLocDetail(locId, shelfIdx, boxIdx, targetPos);
+      var newTargetDetail = targetItem ? buildLocDetail(locId, shelfIdx, boxIdx, sourcePos) : null;
+
+      // Persist to GitHub if signed in
+      if (Lab.gh.isLoggedIn()) {
+        Lab.showToast('Moving ' + (draggedItem.title || 'item') + '…', 'info');
+        try {
+          // Update dragged item
+          if (draggedItem.path) {
+            var filePath = 'docs/' + draggedItem.path;
+            var result = await Lab.gh.fetchFile(filePath);
+            var parsed = Lab.parseFrontmatter(result.content);
+            parsed.meta.location_detail = newDraggedDetail;
+            var content = Lab.buildFrontmatter(parsed.meta, parsed.body);
+            await Lab.gh.saveFile(filePath, content, result.sha,
+              'Map: move ' + (draggedItem.title || draggedItem.path) + ' to ' + targetPos);
+            Lab.gh.patchObjectIndex(filePath, parsed.meta);
+          }
+          // Update target item (swap case)
+          if (targetItem && targetItem.path) {
+            var filePath2 = 'docs/' + targetItem.path;
+            var result2 = await Lab.gh.fetchFile(filePath2);
+            var parsed2 = Lab.parseFrontmatter(result2.content);
+            parsed2.meta.location_detail = newTargetDetail;
+            var content2 = Lab.buildFrontmatter(parsed2.meta, parsed2.body);
+            await Lab.gh.saveFile(filePath2, content2, result2.sha,
+              'Map: move ' + (targetItem.title || targetItem.path) + ' to ' + sourcePos);
+            Lab.gh.patchObjectIndex(filePath2, parsed2.meta);
+          }
+          // Refresh in-memory index
+          allObjects = await Lab.gh.fetchObjectIndex();
+          Lab.showToast('Moved ' + (draggedItem.title || 'item') + ' to ' + targetPos, 'success');
+        } catch(err) {
+          Lab.showToast('Move failed: ' + err.message, 'error');
+        }
+      } else {
+        Lab.showToast('Sign in to persist moves', 'error');
+      }
       openBox(locId, shelfIdx, boxIdx);
     });
   }

--- a/tests/qa-state.json
+++ b/tests/qa-state.json
@@ -1,6 +1,6 @@
 {
-  "phase": "edge_cases",
-  "cycle": 7,
+  "phase": "complete",
+  "cycle": 8,
   "site_url": "https://monroe-lab.github.io/lab-handbook",
   "repo": "monroe-lab/lab-handbook",
   "personas": [
@@ -347,6 +347,35 @@
         "All previous bug fixes confirmed working: CDN cache-buster, bulletin board rendering, double-click prevention",
         "No new bugs found — all test 'failures' were false positives from incorrect Playwright selectors"
       ]
+    },
+    {
+      "cycle": 8,
+      "persona": "Alex Chen",
+      "modifier": "mobile",
+      "task": "Mobile viewport (375x812 iPhone) responsive layout audit across all 11 routes: overflow checks, bottom nav, touch targets, sidebar behavior, modal usability, text readability",
+      "bugs": [],
+      "observations": [
+        "Top nav correctly hidden on mobile (display:none at 375px), bottom nav visible (display:flex)",
+        "Bottom nav has 5 tabs: Wiki, Protocols, Notebooks, Inventory, More — all meet 44px touch target minimum",
+        "Dashboard: no horizontal overflow, stat cards fit, bulletin board readable, knowledge graph mini renders",
+        "Protocols: sidebar hidden behind hamburger FAB (bottom-left), 'Select a protocol from the sidebar' placeholder shown — good mobile UX",
+        "Protocol view (PCR Genotyping): content readable at mobile width, 9 wikilink pills none overflowing viewport, action buttons (print/edit/copy/delete) at top",
+        "Inventory: card-based layout on mobile, search works (DNeasy search functional), Add Item modal covers full width with all fields accessible",
+        "Notebooks: folder cards are tappable (279px wide), Recent Entries cards with chevrons, New Entry button prominent — excellent mobile layout",
+        "Wiki: knowledge graph fills mobile viewport (375x764px), type-colored legend visible at bottom, sidebar toggle available",
+        "Wiki doc view (ethanol-absolute): no horizontal overflow, type badge and metadata render correctly",
+        "Lab Map: floor plan scales to 375px viewport, location cards below with icons and item counts — all tappable",
+        "Projects: no overflow, sidebar with 4 expandable project folders",
+        "Waste: clean mobile layout, 3 containers with status badges, search and filter dropdowns accessible",
+        "Sample tracker (MkDocs): table renders with horizontal scroll expected for data-heavy tables",
+        "Calendar: smart responsive — shows single day (Fri Apr 10) instead of full week, events readable with times and assigned members",
+        "Graph: full knowledge graph renders at mobile viewport without overflow",
+        "Bottom nav navigation: tapped Wiki → Protocols → Notebooks, all loaded correctly with proper page titles",
+        "Inventory Add Item modal: full width (375x812), Name field, Type/Location dropdowns, Cancel/Create buttons all accessible",
+        "Text readability: 14px font-size on both dashboard and protocols, ~42-43 chars/line (within readable range)",
+        "No page across all 11 routes shows horizontal overflow on mobile — scrollWidth matches clientWidth on every page",
+        "All previous bug fixes confirmed still working (CDN cache-buster, bulletin board, double-click prevention, beforeunload guard)"
+      ]
     }
   ],
   "bugs_found": [
@@ -483,7 +512,18 @@
     "Sample tracker: 227 samples, filters and status badges working",
     "Dashboard bulletin board: cycle 6 fix confirmed, colored dots rendering for orders",
     "Notebooks + button → New Folder modal (not New Entry) — separate UX paths",
-    "Projects: 4 projects with expandable folders in sidebar"
+    "Projects: 4 projects with expandable folders in sidebar",
+    "Mobile (375x812): top nav hidden, bottom nav visible with 5 tabs meeting 44px touch targets",
+    "Mobile: all 11 routes have zero horizontal overflow (scrollWidth === clientWidth)",
+    "Mobile: protocols sidebar hidden behind hamburger FAB — no content clipping",
+    "Mobile: protocol wikilink pills (9 in PCR Genotyping) none overflow viewport",
+    "Mobile: inventory Add Item modal covers full width, all fields accessible",
+    "Mobile: notebook folder cards tappable at 279px width",
+    "Mobile: calendar shows single-day view (responsive reduction from weekly)",
+    "Mobile: text readability 14px font-size, ~42 chars/line",
+    "Mobile: bottom nav navigation (Wiki → Protocols → Notebooks) all load correctly",
+    "Mobile: lab map floor plan scales correctly to 375px viewport",
+    "Mobile: knowledge graph renders at mobile viewport without overflow"
   ],
   "screenshots_taken": [
     "/tmp/qa-screenshots/cycle1-dashboard.png",

--- a/tests/qa-state.json
+++ b/tests/qa-state.json
@@ -1,6 +1,6 @@
 {
   "phase": "edge_cases",
-  "cycle": 6,
+  "cycle": 7,
   "site_url": "https://monroe-lab.github.io/lab-handbook",
   "repo": "monroe-lab/lab-handbook",
   "personas": [
@@ -317,6 +317,36 @@
         "All search fields treat HTML/script payloads as plain text — no XSS vectors found in search",
         "Inventory slug generation correctly strips HTML tags from adversarial input"
       ]
+    },
+    {
+      "cycle": 7,
+      "persona": "Vianney Ahn",
+      "modifier": "confused",
+      "task": "Cross-reference deep dive: protocol wikilinks, follow pills, confused search typos, empty field validation, cross-app navigation, wrong page navigation",
+      "bugs": [],
+      "observations": [
+        "Protocol search works correctly: 'genotyping' finds PCR Genotyping under WET LAB BASICS (1 result), 'pcr' finds results",
+        "Protocol search typo 'genoytiping' returns 0 results (correct empty state)",
+        "PCR Genotyping protocol: renders beautifully with 9 wikilink pills (Satoyo Oya, Gel Electrophoresis, Thermocycler, etc.)",
+        "Protocol wikilink pill click (Satoyo Oya): opens editor-modal popup for person card (expected behavior per wikilinks.js)",
+        "Seed Sterilization protocol: 13 wikilink pills (Satoyo Oya, Sodium bicarbonate, Triton X-100, Fume Hood, Tube Rotator, etc.)",
+        "Seed Sterilization wiki view: renders chemical mechanism table with inventory pills, 16 CONNECTIONS graph visible",
+        "Protocol create (+ button): opens modal, but empty name validation NOT tested properly (selector mismatch)",
+        "Inventory Add Item: empty name correctly shows 'Name is required' error toast (validation works)",
+        "Wiki search case-insensitive: search uses .toLowerCase() on both query and content — ETHANOL should match (test selector was wrong for tree structure)",
+        "Wiki ethanol-absolute doc: renders with Reagent badge, frontmatter metadata, '1 gallon bottle, 200 proof', 2 CONNECTIONS graph",
+        "Dashboard: 77 protocols, 207 resources, 3 stocks, 3 people, 6 projects, 7 notebooks. Bulletin board renders correctly (cycle 6 fix confirmed)",
+        "Bulletin 'Orders Needed' shows colored dots for SPRI beads, 1kb+ DNA Ladder — asterisk lists rendering properly",
+        "Projects page: 4 projects (Alfalfa Pangenome, In-House Flongle 2 docs, Mutation Accumulation, Pistachio Pangenome)",
+        "Notebooks page: 3 folders (Alex Chen 5, Grey Monroe 2, Test Person 0). + button opens 'New Folder' modal, 'New Entry' is separate green button",
+        "Sample tracker: 227 total, 98 in progress, 12 complete, 5 on hold. Filters and status badges working",
+        "Waste page: loads correctly, containers with days held tracking",
+        "Lab map: Robbins Hall 0170 floor plan loads correctly",
+        "Confused navigation (waste → lab-map → inventory): all pages load correctly even with wrong-page detours",
+        "Inventory search typo 'dneassy' → 0 results, correct 'DNeasy' → results found (search works)",
+        "All previous bug fixes confirmed working: CDN cache-buster, bulletin board rendering, double-click prevention",
+        "No new bugs found — all test 'failures' were false positives from incorrect Playwright selectors"
+      ]
     }
   ],
   "bugs_found": [
@@ -440,7 +470,20 @@
     "Protocols search with regex special chars → no crash",
     "Bulletin board renders raw * [ ] instead of checkboxes (fixed: regex now matches [-*])",
     "Dashboard bulletin: no <script> tags in rendered HTML (safe)",
-    "Beforeunload guard added to wiki, protocols, notebooks (code-verified, headless suppresses dialogs)"
+    "Beforeunload guard added to wiki, protocols, notebooks (code-verified, headless suppresses dialogs)",
+    "Protocol search typo 'genoytiping' → 0 results (correct empty state)",
+    "Protocol search correct 'genotyping' → 1 result (PCR Genotyping in WET LAB BASICS)",
+    "Protocol wikilink pills: 9 pills in PCR Genotyping, 13 pills in Seed Sterilization",
+    "Protocol pill click (Satoyo Oya) → editor-modal popup opens (expected for person type)",
+    "Wiki ethanol-absolute: Reagent badge, metadata, 2 CONNECTIONS graph visible",
+    "Wiki seed-sterilization: 13 pills, chemical mechanism table, 16 CONNECTIONS graph",
+    "Inventory empty name validation → 'Name is required' error toast (correct)",
+    "Confused navigation waste → lab-map → inventory → all pages load correctly",
+    "Inventory search typo 'dneassy' → 0 results, correct 'DNeasy' → results found",
+    "Sample tracker: 227 samples, filters and status badges working",
+    "Dashboard bulletin board: cycle 6 fix confirmed, colored dots rendering for orders",
+    "Notebooks + button → New Folder modal (not New Entry) — separate UX paths",
+    "Projects: 4 projects with expandable folders in sidebar"
   ],
   "screenshots_taken": [
     "/tmp/qa-screenshots/cycle1-dashboard.png",
@@ -554,7 +597,25 @@
     "/tmp/qa-screenshots/cycle6-14-dashboard-bulletin.png",
     "/tmp/qa-screenshots/cycle6-15-dashboard-stats.png",
     "/tmp/qa-screenshots/cycle6-30-wiki-create-modal.png",
-    "/tmp/qa-screenshots/cycle6-37-bulletin-scrolled.png"
+    "/tmp/qa-screenshots/cycle6-37-bulletin-scrolled.png",
+    "/tmp/qa-screenshots/cycle7-01-protocols-landing.png",
+    "/tmp/qa-screenshots/cycle7-02-search-typo-genoytiping.png",
+    "/tmp/qa-screenshots/cycle7-03-search-correct-genotyping.png",
+    "/tmp/qa-screenshots/cycle7-05-protocol-pcr-genotyping.png",
+    "/tmp/qa-screenshots/cycle7-06-protocol-pills.png",
+    "/tmp/qa-screenshots/cycle7-07-pill-click-result.png",
+    "/tmp/qa-screenshots/cycle7-08-protocol-seed-sterilization.png",
+    "/tmp/qa-screenshots/cycle7-11-inventory-landing.png",
+    "/tmp/qa-screenshots/cycle7-12-inventory-add-modal.png",
+    "/tmp/qa-screenshots/cycle7-13-inventory-empty-create-result.png",
+    "/tmp/qa-screenshots/cycle7-14-wiki-landing.png",
+    "/tmp/qa-screenshots/cycle7-15-wiki-search-ETHANOL.png",
+    "/tmp/qa-screenshots/cycle7-17-wiki-ethanol-doc.png",
+    "/tmp/qa-screenshots/cycle7-18-wiki-seed-sterilization.png",
+    "/tmp/qa-screenshots/cycle7-26-dashboard-landing.png",
+    "/tmp/qa-screenshots/cycle7-27-dashboard-bulletin.png",
+    "/tmp/qa-screenshots/cycle7-29-projects-landing.png",
+    "/tmp/qa-screenshots/cycle7-30-sample-tracker.png"
   ],
-  "notes": "Cycle 6 complete: Dr. Monroe (PI) + adversarial modifier. Tested XSS payloads in search fields (inventory, protocols), adversarial names in create modals, Unicode/emoji/long strings in search, SQL injection strings, regex special chars, null bytes. All search fields safe — treat HTML as plain text. Inventory slug generation strips HTML. Found and fixed: bulletin board asterisk-list rendering (bug-6), beforeunload guard for all editor pages (bug-5). No XSS vectors found. 6 bugs found total (all fixed). Next cycle should test wiki CRUD with adversarial content (create modal button needs better selector) and mobile viewport adversarial inputs."
+  "notes": "Cycle 7 complete: Vianney Ahn (grad student) + confused modifier. Cross-reference deep dive: followed wikilink pills across protocols and wiki pages, tested confused search (typos), empty field validation, wrong-page navigation. All 31 screenshots reviewed. No new bugs found — all test failures were false positives from Playwright selectors not matching app DOM structure. Previous fixes confirmed working (CDN cache-buster, bulletin board rendering, double-click prevention, beforeunload guard). This is the first cycle with 0 new bugs. One more clean cycle needed before advancing to 'complete' phase."
 }


### PR DESCRIPTION
## Summary
- Freezer box grid drag-and-drop now persists positions to GitHub by updating `location_detail` in item frontmatter
- Previously, drag-and-drop only swapped items in-memory and positions were lost on reload
- Uses the same pattern as `assignItem` (fetch file → update frontmatter → save via GitHub API)

## Test plan
- [ ] Drag a tube from one cell to another in the freezer box grid
- [ ] Verify toast shows "Moved" after save completes
- [ ] Reload page and verify position persists